### PR TITLE
Update HELICS GitHub repository url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ contributions must be made under this [LICENSE](LICENSE) in accordance with the 
 
 ## [Code of Conduct](.github/CODE_OF_CONDUCT.md)
 
-If you just have a question check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS-src.png)](https://gitter.im/GMLC-TDC/HELICS-src)
+If you just have a question check out [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS.png)](https://gitter.im/GMLC-TDC/HELICS)
 
 ## How Can I Contribute
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,7 +17,7 @@ If you would like to contribute to the Containers or HELICS project see [CONTRIB
  `**` subcontractor
 
 ## Used Libraries or Code
-### [HELICS](https://github.com/GMLC-TDC/HELICS-src)  
+### [HELICS](https://github.com/GMLC-TDC/HELICS)  
 Most of the original code for this library was pulled from use inside HELICS.  It was pulled out as the containers are not core to HELICS and it was useful as a standalone library so it could have better testing and separation of concerns.  HELICS is released with a BSD-3-Clause license.
 
 ### [googleTest](https://github.com/google/googletest)  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://img.shields.io/badge/License-BSD-blue.svg)](https://github.com/GMLC-TDC/containers/blob/master/LICENSE)
 
 # Containers
-Collection of containers used inside [HELICS](https://github.com/GMLC-TDC/HELICS-src) and supporting repos.  These containers are used for data storage for different purposes inside the code.  In some cases they were mage more general than needed to support other types or be useful elsewhere.
+Collection of containers used inside [HELICS](https://github.com/GMLC-TDC/HELICS) and supporting repos.  These containers are used for data storage for different purposes inside the code.  In some cases they were mage more general than needed to support other types or be useful elsewhere.
 
 ## General Containers
 


### PR DESCRIPTION
Update HELICS-src to HELICS GitHub url for the June 19, 2019 rename.