### PR TITLE
remove use of `return {}` for returning an empty optional 

### DIFF
--- a/benchmarks/SimpleQueueBenchmarks.cpp
+++ b/benchmarks/SimpleQueueBenchmarks.cpp
@@ -107,7 +107,7 @@ class stdqFixture : public benchmark::Fixture {
     {
         std::lock_guard<std::mutex> lk(prot);
         if (q.empty()) {
-            return {};
+            return std::nullopt;
         }
         std::optional<X> v = q.front();
         q.pop();
@@ -204,7 +204,7 @@ class blfFixture : public benchmark::Fixture {
         if (q.pop(val)) {
             return val;
         }
-        return {};
+        return std::nullopt;
     }
 };
 
@@ -297,7 +297,7 @@ class bspscFixture : public benchmark::Fixture {
             q.pop();
             return ret;
         }
-        return {};
+        return std::nullopt;
     }
 };
 
@@ -360,7 +360,7 @@ class mcFixture : public benchmark::Fixture {
         if (q.try_dequeue(v)) {
             return v;
         }
-        return {};
+        return std::nullopt;
     }
 };
 

--- a/gmlc/containers/BlockingPriorityQueue.hpp
+++ b/gmlc/containers/BlockingPriorityQueue.hpp
@@ -244,7 +244,7 @@ the two locks will reduce contention in most cases.
                 return priorityQueue.front();
             }
             if (pullElements.empty()) {
-                return {};
+                return std::nullopt;
             }
 
             auto t = pullElements.back();
@@ -425,7 +425,7 @@ any meaning depending on the number of consumers
         }
         checkPullAndSwap();
         if (pullElements.empty()) {
-            return {};
+            return std::nullopt;
         }
         // do it this way to allow movable only types
         std::optional<T> val(std::move(pullElements.back()));

--- a/gmlc/containers/BlockingQueue.hpp
+++ b/gmlc/containers/BlockingQueue.hpp
@@ -196,7 +196,7 @@ contention the two locks will reduce contention in most cases.
             std::lock_guard<MUTEX> lock(m_pullLock);
 
             if (pullElements.empty()) {
-                return {};
+                return std::nullopt;
             }
 
             auto t = pullElements.back();
@@ -342,7 +342,7 @@ any meaning depending on the number of consumers
         std::lock_guard<MUTEX> pullLock(m_pullLock);  // first pullLock
         checkPullAndSwap();
         if (pullElements.empty()) {
-            return {};
+            return std::nullopt;
         }
         std::optional<T> val(
             std::move(pullElements.back()));  // do it this way to allow

--- a/gmlc/containers/DualMappedPointerVector.hpp
+++ b/gmlc/containers/DualMappedPointerVector.hpp
@@ -53,7 +53,7 @@ namespace containers {
             if (fnd != lookup1.end()) {
                 auto fnd2 = lookup2.find(searchValue2);
                 if (fnd2 != lookup2.end()) {
-                    return {};
+                    return std::nullopt;
                 }
             }
             auto index = dataStorage.size();
@@ -73,7 +73,7 @@ namespace containers {
             if (fnd != lookup1.end()) {
                 auto fnd2 = lookup2.find(searchValue2);
                 if (fnd2 != lookup2.end()) {
-                    return {};
+                    return std::nullopt;
                 }
             }
             auto index = dataStorage.size();
@@ -93,7 +93,7 @@ namespace containers {
         {
             auto fnd = lookup1.find(searchValue1);
             if (fnd != lookup1.end()) {
-                return {};
+                return std::nullopt;
             }
             auto index = dataStorage.size();
             dataStorage.emplace_back(
@@ -111,7 +111,7 @@ namespace containers {
         {
             auto fnd = lookup2.find(searchValue2);
             if (fnd != lookup2.end()) {
-                return {};
+                return std::nullopt;
             }
             auto index = dataStorage.size();
             dataStorage.emplace_back(

--- a/gmlc/containers/DualStringMappedVector.hpp
+++ b/gmlc/containers/DualStringMappedVector.hpp
@@ -55,7 +55,7 @@ or by numerical index
             if (fnd != lookup1.end()) {
                 auto fnd2 = lookup2.find(searchValue2);
                 if (fnd2 != lookup2.end()) {
-                    return {};
+                    return std::nullopt;
                 }
             }
             auto index = dataStorage.size();
@@ -80,7 +80,7 @@ or by numerical index
         {
             auto fnd = lookup1.find(searchValue1);
             if (fnd != lookup1.end()) {
-                return {};
+                return std::nullopt;
             }
             auto index = dataStorage.size();
             dataStorage.emplace_back(std::forward<Us>(data)...);
@@ -103,7 +103,7 @@ or by numerical index
         {
             auto fnd = lookup2.find(searchValue2);
             if (fnd != lookup2.end()) {
-                return {};
+                return std::nullopt;
             }
             auto index = dataStorage.size();
             dataStorage.emplace_back(std::forward<Us>(data)...);

--- a/gmlc/containers/MappedPointerVector.hpp
+++ b/gmlc/containers/MappedPointerVector.hpp
@@ -35,7 +35,7 @@ class MappedPointerVector {
     {
         auto fnd = lookup.find(searchValue);
         if (fnd != lookup.end()) {
-            return {};
+            return std::nullopt;
         }
         auto index = dataStorage.size();
         dataStorage.emplace_back(std::move(ptr));
@@ -48,7 +48,7 @@ class MappedPointerVector {
     {
         auto fnd = lookup.find(searchValue);
         if (fnd != lookup.end()) {
-            return {};
+            return std::nullopt;
         }
         auto index = dataStorage.size();
         dataStorage.emplace_back(

--- a/gmlc/containers/StringMappedVector.hpp
+++ b/gmlc/containers/StringMappedVector.hpp
@@ -41,7 +41,7 @@ with limited to no removal since removal is a rather expensive operation
         {
             auto fnd = lookup.find(searchValue);
             if (fnd != lookup.end()) {
-                return {};
+                return std::nullopt;
             }
             auto index = dataStorage.size();
             dataStorage.emplace_back(std::forward<Us>(data)...);

--- a/tests/PriorityBlockingQueueTests.cpp
+++ b/tests/PriorityBlockingQueueTests.cpp
@@ -19,7 +19,7 @@ All rights reserved. SPDX-License-Identifier: BSD-3-Clause
 using namespace gmlc::containers;
 
 /** test basic operations */
-TEST(blocking_priority_queue_tests, basic_tests)
+TEST(blocking_priority_queue, basic_tests)
 {
     BlockingPriorityQueue<int> sq;
 
@@ -50,7 +50,7 @@ TEST(blocking_priority_queue_tests, basic_tests)
 }
 
 /** test with a move only element*/
-TEST(blocking_priority_queue_tests, move_only_tests)
+TEST(blocking_priority_queue, move_only_tests)
 {
     BlockingPriorityQueue<std::unique_ptr<double>> sq;
 
@@ -77,7 +77,7 @@ TEST(blocking_priority_queue_tests, move_only_tests)
 
 /** test the ordering with a larger number of inputs*/
 
-TEST(blocking_priority_queue_tests, ordering_tests)
+TEST(blocking_priority_queue, ordering_tests)
 {
     BlockingPriorityQueue<int> sq;
 
@@ -105,7 +105,7 @@ TEST(blocking_priority_queue_tests, ordering_tests)
     EXPECT_TRUE(sq.empty());
 }
 
-TEST(blocking_priority_queue_tests, emplace_tests)
+TEST(blocking_priority_queue, emplace_tests)
 {
     BlockingPriorityQueue<std::pair<int, double>> sq;
 
@@ -126,7 +126,7 @@ TEST(blocking_priority_queue_tests, emplace_tests)
     EXPECT_EQ(b->second, 34.1);
 }
 
-TEST(blocking_priority_queue_tests, clear_tests)
+TEST(blocking_priority_queue, clear_tests)
 {
     BlockingPriorityQueue<int64_t> sq;
     sq.push(10);
@@ -142,7 +142,7 @@ TEST(blocking_priority_queue_tests, clear_tests)
     EXPECT_TRUE(sq.empty());
 }
 
-TEST(blocking_priority_queue_tests, multithreaded_tests_wait)
+TEST(blocking_priority_queue, multithreaded_tests_wait)
 {
     BlockingPriorityQueue<std::pair<int64_t, int64_t>> sq;
     auto t1 = [&sq]() {
@@ -216,7 +216,7 @@ TEST(blocking_priority_queue_tests, multithreaded_tests_wait)
     res3.join();
 }
 /** test with single consumer/single producer*/
-TEST(blocking_priority_queue_tests, multithreaded_tests)
+TEST(blocking_priority_queue, multithreaded_tests)
 {
     BlockingPriorityQueue<int64_t> sq(1010000);
 
@@ -253,7 +253,7 @@ TEST(blocking_priority_queue_tests, multithreaded_tests)
 }
 
 /** test with single consumer / single producer */
-TEST(blocking_priority_queue_tests, pop_tests)
+TEST(blocking_priority_queue, pop_tests)
 {
     BlockingPriorityQueue<int64_t> sq(1010000);
 
@@ -291,7 +291,7 @@ TEST(blocking_priority_queue_tests, pop_tests)
 }
 
 /** test with multiple consumer/single producer*/
-TEST(blocking_priority_queue_tests, multithreaded_tests2)
+TEST(blocking_priority_queue, multithreaded_tests2)
 {
     BlockingPriorityQueue<int64_t> sq(1010000);
 
@@ -338,7 +338,7 @@ TEST(blocking_priority_queue_tests, multithreaded_tests2)
 }
 
 /** test with multiple producer/multiple consumer*/
-TEST(blocking_priority_queue_tests, multithreaded_tests3)
+TEST(blocking_priority_queue, multithreaded_tests3)
 {
     BlockingPriorityQueue<int64_t> sq;
     sq.reserve(3'010'000);
@@ -391,7 +391,7 @@ TEST(blocking_priority_queue_tests, multithreaded_tests3)
 }
 
 /** test with multiple producer/multiple consumer*/
-TEST(blocking_priority_queue_tests, multithreaded_tests3_pop)
+TEST(blocking_priority_queue, multithreaded_tests3_pop)
 {
     BlockingPriorityQueue<int64_t> sq;
     sq.reserve(3'010'000);
@@ -404,8 +404,8 @@ TEST(blocking_priority_queue_tests, multithreaded_tests3_pop)
     };
 
     auto cons = [&]() {
-        auto res = sq.pop();
-        int64_t cnt = 0;
+        int64_t res{1};
+        int64_t cnt{ 0 };
         while (res >= 0) {
             ++cnt;
             res = sq.pop();
@@ -431,7 +431,7 @@ TEST(blocking_priority_queue_tests, multithreaded_tests3_pop)
     auto V1 = res1.get();
     auto V2 = res2.get();
 
-    EXPECT_EQ(V1 + V2 + V3, 3'000'000);
+    EXPECT_EQ(V1 + V2 + V3, 3'000'003);
 
     std::cout << "production complete" << std::endl;
     c1thread.join();
@@ -439,7 +439,7 @@ TEST(blocking_priority_queue_tests, multithreaded_tests3_pop)
 }
 
 /** test with multiple producer/multiple consumer*/
-TEST(blocking_priority_queue_tests, pop_callback_tests)
+TEST(blocking_priority_queue, pop_callback_tests)
 {
     BlockingPriorityQueue<int64_t> sq;
     int pushcnt = 0;

--- a/tests/PriorityBlockingQueueTests.cpp
+++ b/tests/PriorityBlockingQueueTests.cpp
@@ -405,7 +405,7 @@ TEST(blocking_priority_queue, multithreaded_tests3_pop)
 
     auto cons = [&]() {
         int64_t res{1};
-        int64_t cnt{ 0 };
+        int64_t cnt{0};
         while (res >= 0) {
             ++cnt;
             res = sq.pop();


### PR DESCRIPTION
since that triggers warnings on some platforms.